### PR TITLE
fix/rt: Move nrf52840-hal to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nrf52840-hal = "0.10.0"
-panic-halt  = "0.2.0"
 cortex-m-rt = "0.6.12"
 embedded-hal = "0.2.4"
 cortex-m-semihosting = "0.3.5"
@@ -39,4 +37,7 @@ debug = true
 [patch.crates-io]
 nrf-hal-common = {version = "0.10.0", path = '/Users/Nil/devspace/rust/projects/rustscratchspace/nrf-hal/nrf-hal-common' }
 
+[dev-dependencies]
+nrf52840-hal = "0.10.0"
+panic-halt  = "0.2.0"
 


### PR DESCRIPTION
I'm trying the library on STM32 L4 architecture (`stm32l4xx-hal`).
The problem is the dependency of `nrf52840-hal` doesn't allow other HAL implementations.
As `nrf52840-hal` is only used in `examples`, it could be placed under `dev-dependencies`.
Fixes #2 .